### PR TITLE
Fix complex enum option and reserved parsing

### DIFF
--- a/src/Text/Protobuf/Parser/Enum.hs
+++ b/src/Text/Protobuf/Parser/Enum.hs
@@ -53,11 +53,23 @@ parseEnum =
         )
   where
     name = protoName
-    fields = try parseEnumField `sepEndBy1` char ';'
+    fields = many1 (try parseEnumField)
 
 parseEnumField :: Parser EnumField
 parseEnumField =
-  spaces' *> (try reservedField <|> try optionField <|> try valueField)
+  spaces'
+    *> ( try
+           ( reservedField
+               <* spaces'
+               <* char ';'
+           )
+           <|> try optionField
+           <|> try
+             ( valueField
+                 <* spaces'
+                 <* char ';'
+             )
+       )
   where
     fieldName = spaces' *> protoName
     fieldNumber = spaces' *> char '=' *> spaces' *> enumNumber
@@ -75,7 +87,10 @@ parseEnumField =
     optionField = EnumOption <$> parseOption
     reservedField =
       EnumReserved
-        <$> (string "reserved" *> spaces' *> reservedValues)
+        <$> ( string "reserved"
+                *> spaces'
+                *> reservedValues
+            )
 
 enumNumber :: Parser EnumNumber
 enumNumber =

--- a/src/Text/Protobuf/Parser/Reserved.hs
+++ b/src/Text/Protobuf/Parser/Reserved.hs
@@ -27,7 +27,7 @@ reservedNumbers single range =
     numbers =
       try
         ( (\l r -> [l .. r])
-            <$> range
+            <$> (spaces' *> range)
             <* spaces'
             <* string "to"
             <* spaces'

--- a/test/E2E/Files.hs
+++ b/test/E2E/Files.hs
@@ -93,7 +93,17 @@ testFiles = TestCase $ do
             [ Text.Protobuf.Types.Enum
                 "Data"
                 [ EnumOption (Option "allow_alias" (BoolValue True)),
-                  EnumReserved (ReservedEnumNumbers [1, 2, 3]),
+                  EnumReserved
+                    ( ReservedEnumNumbers
+                        [ 2,
+                          15,
+                          9,
+                          10,
+                          11,
+                          4294967294,
+                          4294967295
+                        ]
+                    ),
                   EnumValue "DATA_UNSPECIFIED" 0 [],
                   EnumValue
                     "DATA_SEARCH"

--- a/test/E2E/Files.hs
+++ b/test/E2E/Files.hs
@@ -92,7 +92,9 @@ testFiles = TestCase $ do
           enums =
             [ Text.Protobuf.Types.Enum
                 "Data"
-                [ EnumValue "DATA_UNSPECIFIED" 0 [],
+                [ EnumOption (Option "allow_alias" (BoolValue True)),
+                  EnumReserved (ReservedEnumNumbers [1, 2, 3]),
+                  EnumValue "DATA_UNSPECIFIED" 0 [],
                   EnumValue
                     "DATA_SEARCH"
                     1

--- a/test/E2E/protofiles/enum.proto
+++ b/test/E2E/protofiles/enum.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 
 enum Data {
+  option allow_alias = true;
+  reserved 2, 15, 9 to 11, 4294967294 to max;
   DATA_UNSPECIFIED = 0;
   DATA_SEARCH = 1 [deprecated = true];
   DATA_DISPLAY = 2 [

--- a/test/Unit/Text/Protobuf/Parser/Enum.hs
+++ b/test/Unit/Text/Protobuf/Parser/Enum.hs
@@ -87,6 +87,10 @@ testEnumFieldParser = TestCase $ do
     "singleReserved"
     (EnumReserved (ReservedEnumNumbers [1]))
     (fromRight emptyDefault (parse parseEnumField "" "reserved 1;"))
+  assertEqual
+    "uneven reserved single numbers before range"
+    (EnumReserved (ReservedEnumNumbers [2, 15, 9, 10, 11, 4294967294, 0xFFFFFFFF]))
+    (fromRight emptyDefault (parse parseEnumField "" "reserved 2, 15, 9 to 11, 4294967294 to max;"))
   -- reserved name --
   assertEqual
     "emptyReservedName"

--- a/test/Unit/Text/Protobuf/Parser/Enum.hs
+++ b/test/Unit/Text/Protobuf/Parser/Enum.hs
@@ -41,15 +41,15 @@ testEnumFieldParser = TestCase $ do
   assertEqual
     "enumEntry"
     (EnumValue "TEST" 0 [])
-    (fromRight emptyDefault (parse parseEnumField "" "TEST = 0"))
+    (fromRight emptyDefault (parse parseEnumField "" "TEST = 0;"))
   assertEqual
     "enumEntry"
     (EnumValue "MORE" 1 [])
-    (fromRight emptyDefault (parse parseEnumField "" "MORE = 1"))
+    (fromRight emptyDefault (parse parseEnumField "" "MORE = 1;"))
   assertEqual
     "enumEntry"
     (EnumValue "UNDER_SCORE" 42 [])
-    (fromRight emptyDefault (parse parseEnumField "" "UNDER_SCORE = 42"))
+    (fromRight emptyDefault (parse parseEnumField "" "UNDER_SCORE = 42;"))
   -- reserved number --
   assertEqual
     "empytReserved"
@@ -62,44 +62,44 @@ testEnumFieldParser = TestCase $ do
   assertEqual
     "multiReserved"
     (EnumReserved (ReservedEnumNumbers [1, 2]))
-    (fromRight emptyDefault (parse parseEnumField "" "reserved 1, 2"))
+    (fromRight emptyDefault (parse parseEnumField "" "reserved 1, 2;"))
   assertEqual
     "multiReserved"
     (EnumReserved (ReservedEnumNumbers [1, 3, 5]))
-    (fromRight emptyDefault (parse parseEnumField "" "reserved 1, 3, 5"))
+    (fromRight emptyDefault (parse parseEnumField "" "reserved 1, 3, 5;"))
   assertEqual
     "multiReserved"
     (EnumReserved (ReservedEnumNumbers [1, 2, 3]))
-    (fromRight emptyDefault (parse parseEnumField "" "reserved 1 to 3"))
+    (fromRight emptyDefault (parse parseEnumField "" "reserved 1 to 3;"))
   assertEqual
     "multiReserved"
     (EnumReserved (ReservedEnumNumbers [0, 1, 2, 3]))
-    (fromRight emptyDefault (parse parseEnumField "" "reserved min to 3"))
+    (fromRight emptyDefault (parse parseEnumField "" "reserved min to 3;"))
   assertEqual
     "multiReserved"
     (EnumReserved (ReservedEnumNumbers [4294967294, 0xFFFFFFFF]))
-    (fromRight emptyDefault (parse parseEnumField "" "reserved 4294967294 to max"))
+    (fromRight emptyDefault (parse parseEnumField "" "reserved 4294967294 to max;"))
   assertEqual
     "singleReserved"
     (EnumReserved (ReservedEnumNumbers [0]))
-    (fromRight emptyDefault (parse parseEnumField "" "reserved 0"))
+    (fromRight emptyDefault (parse parseEnumField "" "reserved 0;"))
   assertEqual
     "singleReserved"
     (EnumReserved (ReservedEnumNumbers [1]))
-    (fromRight emptyDefault (parse parseEnumField "" "reserved 1"))
+    (fromRight emptyDefault (parse parseEnumField "" "reserved 1;"))
   -- reserved name --
   assertEqual
     "emptyReservedName"
     False
-    (isRight (parse parseEnumField "" "reserved"))
+    (isRight (parse parseEnumField "" "reserved;"))
   assertEqual
     "singleReservedName"
     (EnumReserved (ReservedEnumNames (ReservedNames ["FOO"])))
-    (fromRight emptyDefault (parse parseEnumField "" "reserved \"FOO\""))
+    (fromRight emptyDefault (parse parseEnumField "" "reserved \"FOO\";"))
   assertEqual
     "multiReservedName"
     (EnumReserved (ReservedEnumNames (ReservedNames ["FOO", "BAR"])))
-    (fromRight emptyDefault (parse parseEnumField "" "reserved \"FOO\", \"BAR\""))
+    (fromRight emptyDefault (parse parseEnumField "" "reserved \"FOO\", \"BAR\";"))
   -- option --
   assertEqual
     "empty"

--- a/test/Unit/Text/Protobuf/Parser/Option.hs
+++ b/test/Unit/Text/Protobuf/Parser/Option.hs
@@ -47,6 +47,13 @@ testImport = TestCase $ do
         testOption
         (parse parseOption "" "option optimize_for = SPEED;")
     )
+  assertEqual
+    "allow alias"
+    (Option "allow_alias" (BoolValue True))
+    ( fromRight
+        testOption
+        (parse parseOption "" "option allow_alias = true;")
+    )
 
 testDefaultFieldOption :: [FieldOption]
 testDefaultFieldOption = [FieldOption "test" (StringValue "fail")]


### PR DESCRIPTION
Fixes #2 by aligning `;` separation and removing spaces in front of number ranges