### PR TITLE
Add nested messages

### DIFF
--- a/src/Text/Protobuf/Parser/Message.hs
+++ b/src/Text/Protobuf/Parser/Message.hs
@@ -28,10 +28,7 @@ parseMessage' p = do
     )
 
 parseMessage :: Parser Message
-parseMessage = parseMessage''
-
-parseMessage'' :: Parser Message
-parseMessage'' =
+parseMessage =
   Message
     <$> ( spaces'
             *> string "message"
@@ -57,7 +54,7 @@ parseMessageField =
            <|> try oneofField
            <|> (OptionMessageField <$> try parseOption <* fieldSeparator)
            <|> (EnumMessageField <$> try parseEnum)
-           <|> (NestedMessage <$> try parseMessage'')
+           <|> (NestedMessage <$> try parseMessage)
        )
   where
     fieldName = spaces' *> protoName

--- a/src/Text/Protobuf/Types.hs
+++ b/src/Text/Protobuf/Types.hs
@@ -86,6 +86,7 @@ data MessageField
   | OneOfMessageField Name [MessageField]
   | EnumMessageField Text.Protobuf.Types.Enum
   | OptionMessageField Option
+  | NestedMessage Message
   deriving (Show, Eq)
 
 data Message
@@ -316,6 +317,8 @@ instance Pretty MessageField where
     pretty option
   pretty (EnumMessageField enum) =
     pretty enum
+  pretty (NestedMessage msg) =
+    pretty msg
 
 instance Pretty MessageReservedValues where
   pretty (ReservedMessageNumbers numbers) =

--- a/test/Unit/Text/Protobuf/Parser/Message.hs
+++ b/test/Unit/Text/Protobuf/Parser/Message.hs
@@ -117,6 +117,23 @@ testFieldOptionProto =
         [FieldOption "default" (BoolValue True)]
     ]
 
+testNestedMessage :: String
+testNestedMessage =
+  "message Foo {\
+  \message Bar {\
+  \int32 foo = 1;\
+  \}\
+  \Bar bar = 1;\
+  \}"
+
+testNestedMessagesProto :: Message
+testNestedMessagesProto =
+  Message
+    "Foo"
+    [ NestedMessage (Message "Bar" [ImplicitMessageField (Scalar (IntType Int32)) "foo" 1 []]),
+      ImplicitMessageField (Compound "Bar") "bar" 1 []
+    ]
+
 testSimple :: Test
 testSimple = TestCase $ do
   assertEqual
@@ -163,3 +180,7 @@ testSimple = TestCase $ do
     "field option"
     testFieldOptionProto
     (fromRight failMessage (parse parseMessage "" testFieldOption))
+  assertEqual
+    "embedded message"
+    testNestedMessagesProto
+    (fromRight failMessage (parse parseMessage "" testNestedMessage))


### PR DESCRIPTION
Message types can now be nested as described in [the official spec](https://protobuf.dev/programming-guides/proto3/#nested)

Additionally, fixed a bug where `oneOfFields` and `Enums` had to be separated by `;` in the message definition